### PR TITLE
fix: try-catch in git import

### DIFF
--- a/src/review/bot/git_interface.py
+++ b/src/review/bot/git_interface.py
@@ -1,9 +1,17 @@
 # Copyright (c) 2023 ANSYS, Inc. All rights reserved
 """Interface module for local GIT files."""
+import logging
 import os
 from pathlib import Path
 
-from git import Repo
+LOG = logging.getLogger(__name__)
+LOG.setLevel("DEBUG")
+
+try:
+    from git import Repo
+except ImportError as err:
+    LOG.warning(f"Error while importing git: {err}")
+    LOG.warning(f"Usage of review_bot might lead to errors.")
 
 
 class LocalGit:

--- a/src/review/bot/open_ai_interface.py
+++ b/src/review/bot/open_ai_interface.py
@@ -7,6 +7,8 @@ import openai
 
 import review.bot.defaults as defaults
 from review.bot.exceptions import EmptyOpenAIResponseException
+from review.bot.gh_interface import get_changed_files_and_contents
+from review.bot.git_interface import LocalGit
 from review.bot.misc import _set_open_ai_config, add_line_numbers, parse_suggestions
 
 LOG = logging.getLogger(__name__)
@@ -51,8 +53,6 @@ def review_patch(
     list[dict]
         A dictionary containing suggestions for the reviewed patch.
     """
-    from review.bot.gh_interface import get_changed_files_and_contents
-
     # Fetch changed files and contents
     changed_files = get_changed_files_and_contents(
         owner, repo, pr, gh_access_token=gh_access_token
@@ -112,8 +112,6 @@ def review_patch_local(
     list[dict]
         A dictionary containing suggestions for the reviewed patch.
     """
-    from review.bot.git_interface import LocalGit
-
     # load repo and change branch if it applies
     local_repo = LocalGit(repo)
     if branch is not None:

--- a/src/review/bot/open_ai_interface.py
+++ b/src/review/bot/open_ai_interface.py
@@ -7,8 +7,6 @@ import openai
 
 import review.bot.defaults as defaults
 from review.bot.exceptions import EmptyOpenAIResponseException
-from review.bot.gh_interface import get_changed_files_and_contents
-from review.bot.git_interface import LocalGit
 from review.bot.misc import _set_open_ai_config, add_line_numbers, parse_suggestions
 
 LOG = logging.getLogger(__name__)
@@ -53,6 +51,8 @@ def review_patch(
     list[dict]
         A dictionary containing suggestions for the reviewed patch.
     """
+    from review.bot.gh_interface import get_changed_files_and_contents
+
     # Fetch changed files and contents
     changed_files = get_changed_files_and_contents(
         owner, repo, pr, gh_access_token=gh_access_token
@@ -112,6 +112,8 @@ def review_patch_local(
     list[dict]
         A dictionary containing suggestions for the reviewed patch.
     """
+    from review.bot.git_interface import LocalGit
+
     # load repo and change branch if it applies
     local_repo = LocalGit(repo)
     if branch is not None:


### PR DESCRIPTION
Use try-catch around git import to avoid issues in machines that do not have git installed locally.